### PR TITLE
Create dsa_pub.pem on Linux

### DIFF
--- a/setup_fresh_env.sh
+++ b/setup_fresh_env.sh
@@ -282,8 +282,7 @@ setupEnv()
 			fi
 		fi
 
-	elif [[ $osName == "mac" ]];
-	then
+	else
 		local dsa_pub_key="resources/dsa_pub.pem"
 		touch "$dsa_pub_key"
 


### PR DESCRIPTION
Linux builds fail currently because dsa_pub.pem isn't created. I suspect that there is a typo in setup_fresh_env.sh because there are two succeeding 'elif [[ $osName == "mac" ]];' cases. I changed the last one in an else statement, so that dsa_pub.pem is always created.