### PR TITLE
Only set QPainter::Antialiasing hint once

### DIFF
--- a/libs/QtMate/graph/view.cpp
+++ b/libs/QtMate/graph/view.cpp
@@ -37,7 +37,7 @@ GraphicsView::GraphicsView(QWidget* parent)
 	setResizeAnchor(NoAnchor);
 	setTransformationAnchor(AnchorUnderMouse);
 	setDragMode(QGraphicsView::ScrollHandDrag);
-	setRenderHints(QPainter::Antialiasing | QPainter::TextAntialiasing | QPainter::Antialiasing | QPainter::SmoothPixmapTransform);
+	setRenderHints(QPainter::Antialiasing | QPainter::TextAntialiasing | QPainter::SmoothPixmapTransform);
 }
 
 void GraphicsView::mousePressEvent(QMouseEvent* event)

--- a/libs/QtMate/material/helper.cpp
+++ b/libs/QtMate/material/helper.cpp
@@ -36,7 +36,7 @@ QIcon generateIcon(QString const& what, QColor const& color)
 		pixmap.fill(Qt::transparent);
 
 		QPainter painter{ &pixmap };
-		painter.setRenderHints(QPainter::Antialiasing | QPainter::TextAntialiasing | QPainter::Antialiasing);
+		painter.setRenderHints(QPainter::Antialiasing | QPainter::TextAntialiasing);
 
 		QFont font{ "Material Icons" };
 		font.setStyleStrategy(QFont::PreferQuality);

--- a/src/connectionMatrix/paintHelper.cpp
+++ b/src/connectionMatrix/paintHelper.cpp
@@ -196,7 +196,6 @@ QPainterPath buildHeaderArrowPath(QRect const& rect, Qt::Orientation const orien
 void drawCapabilities(QPainter* painter, QRect const& rect, Model::IntersectionData::Type const type, Model::IntersectionData::State const state, Model::IntersectionData::Flags const& flags)
 {
 	painter->setRenderHint(QPainter::Antialiasing);
-	painter->setRenderHint(QPainter::Antialiasing);
 
 	auto const connected = state != Model::IntersectionData::State::NotConnected;
 


### PR DESCRIPTION
Minor cleanup.
Noticed this because I had local changes getting rid of deprecated Qt API to avoid `-Werror`.