### PR TITLE
#183: qt: Fixing deprecated warning, and provides alternative for earlier version than qt 6.7.0

### DIFF
--- a/src/discoveredEntitiesView.cpp
+++ b/src/discoveredEntitiesView.cpp
@@ -84,7 +84,11 @@ DiscoveredEntitiesView::DiscoveredEntitiesView(QWidget* parent)
 			emit filterChanged(text);
 		});
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
+	connect(&_filterLinkedCheckbox, &QCheckBox::checkStateChanged, &_filterLinkedCheckbox,
+#else
 	connect(&_filterLinkedCheckbox, &QCheckBox::stateChanged, &_filterLinkedCheckbox,
+#endif // QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
 		[this](int state)
 		{
 			emit filterLinkStateChanged(static_cast<Qt::CheckState>(state) == Qt::CheckState::Checked, _searchLineEdit.text());


### PR DESCRIPTION
Because of the -Werr warning and latest qt's version,  will generate a deprecated warning and stop the compilation.
 A small patch was provided to integrate it in the mainline so that newer qt can compile Hive.